### PR TITLE
Add Android SDK setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -e
+
+# Directory where the Android SDK will be installed
+ANDROID_SDK_ROOT=${ANDROID_SDK_ROOT:-"$HOME/android-sdk"}
+CMDLINE_VERSION=10406996
+
+# Install prerequisites
+sudo apt-get update
+sudo apt-get install -y wget unzip openjdk-11-jdk
+
+mkdir -p "$ANDROID_SDK_ROOT"
+cd "$ANDROID_SDK_ROOT"
+
+# Download command line tools
+wget -q "https://dl.google.com/android/repository/commandlinetools-linux-${CMDLINE_VERSION}_latest.zip" -O cmdline-tools.zip
+unzip -q cmdline-tools.zip -d cmdline-tools
+mv cmdline-tools/cmdline-tools cmdline-tools/latest
+rm cmdline-tools.zip
+
+export PATH="$PATH:$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:$ANDROID_SDK_ROOT/platform-tools"
+
+# Accept licenses and install basic packages
+yes | sdkmanager --licenses > /dev/null
+sdkmanager --install \
+    "platform-tools" \
+    "platforms;android-34" \
+    "build-tools;34.0.0"
+
+# Create local.properties for Gradle builds if inside repo
+if [ -d "./P2PChessApp" ]; then
+    echo "sdk.dir=$ANDROID_SDK_ROOT" > ./P2PChessApp/local.properties
+fi
+
+echo "Android SDK installed at $ANDROID_SDK_ROOT"


### PR DESCRIPTION
## Summary
- provide `setup.sh` for installing Android SDK

## Testing
- `./gradlew testDebugUnitTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f3bd5b3348320b233e5487d4ccaff