### PR TITLE
Fix Kotlin warnings

### DIFF
--- a/P2PChessApp/app/src/main/java/com/example/p2pchessapp/model/ChessModel.kt
+++ b/P2PChessApp/app/src/main/java/com/example/p2pchessapp/model/ChessModel.kt
@@ -214,7 +214,7 @@ public class ChessBoard {
         if (!isValidMove(move)) return false // This will also check for self-check
 
         // Perform the move
-        val captured = getPieceAt(move.to) // Could be different from move.capturedPiece if not pre-validated
+        // Capture any existing piece at the destination square (if present)
         setPieceAt(move.to, pieceToMove)
         setPieceAt(move.from, null)
         pieceToMove.hasMoved = true


### PR DESCRIPTION
## Summary
- remove unused variable from `ChessModel`
- use `WifiP2pInfo` instead of deprecated `NetworkInfo` in `WifiDirectBroadcastReceiver`

## Testing
- `./gradlew testDebugUnitTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881f26286008320b48e258801d4f140